### PR TITLE
Add backlog system and update command documentation

### DIFF
--- a/.claude/backlog/README.md
+++ b/.claude/backlog/README.md
@@ -1,0 +1,34 @@
+# Feature Backlog
+
+Ideas and features captured for future consideration. This is **not** a task list - items here are exploratory, not actionable.
+
+## Workflow
+
+1. **Capture** - Ideas go here with description, category, and open questions
+2. **Explore** - When ready to act, create a PRD in `.claude/plans/`
+3. **Execute** - PRD defines epic, milestones, and tasks
+
+## Entry Format
+
+Each feature is a markdown file with:
+
+- **Title** - Clear, descriptive name
+- **Category** - Maps to Atlas module system (core, voice, security, etc.)
+- **Captured** - Date the idea was recorded
+- **Description** - What the feature is and why it matters
+- **Origin** - What sparked this idea (context for future you)
+- **Open Questions** - Things to figure out before it becomes actionable
+- **Related Ideas** - Links to connected backlog items
+
+## Categories
+
+Align with Atlas modules:
+- `core` - CORE skill, identity, base infrastructure
+- `voice` - TTS, voice feedback system
+- `security` - Protection patterns, hooks
+- `skills` - Skill system, new skills
+- `commands` - Slash commands
+- `hooks` - Lifecycle hooks
+- `memory` - MEMORY system
+- `modules` - Module/export system itself
+- `observability` - Dashboard, monitoring

--- a/.claude/backlog/atlas-as-claude-code-plugin.md
+++ b/.claude/backlog/atlas-as-claude-code-plugin.md
@@ -1,0 +1,36 @@
+# Atlas as Claude Code Plugin
+
+**Category:** core / modules
+**Captured:** 2026-01-17
+
+## Description
+
+Transform Atlas from a standalone configuration system into a proper Claude Code plugin. This would allow Atlas and its modules to be enabled/disabled cleanly, making it easy to test other Claude Code frameworks, tools, and utilities without being locked into Atlas's approach.
+
+## Origin
+
+Desire to explore the Claude Code plugin ecosystem while maintaining Atlas's modular architecture. Avoid painting into a corner with hard dependencies.
+
+**Tools to test:**
+- AgentOS
+- Ralph Wiggum
+- BMAD Method
+- Taskmaster
+- Spec-kit
+- PAI (fresh install, not synced)
+
+**Goal:** Zero friction, plug-and-play. Full swap between Atlas and other tools - not just coexistence.
+
+## Open Questions
+
+- What is the current Claude Code plugin specification/format?
+- How do plugins interact with hooks, skills, and commands?
+- Can individual Atlas modules become sub-plugins?
+- What's the migration path from current structure to plugin format?
+- How would enable/disable work for nested modules?
+- What does "disable Atlas" actually mean? (remove from settings.json? rename CLAUDE.md?)
+
+## Related Ideas
+
+- [[observability-dashboard-overhaul]] - Both aim for modularity and reduced lock-in
+- [[claude-canvas-ghostty-integration]] - Another Claude Code plugin to evaluate/extend

--- a/.claude/backlog/claude-canvas-ghostty-integration.md
+++ b/.claude/backlog/claude-canvas-ghostty-integration.md
@@ -1,0 +1,47 @@
+# Claude Canvas / Ghostty Integration
+
+**Category:** core / modules
+**Captured:** 2026-01-17
+
+## Description
+
+Investigate claude-canvas (TUI toolkit that gives Claude Code its own display) and explore extending it to support Ghostty terminal panes/tabs instead of tmux.
+
+**Source:** https://github.com/dvdsgl/claude-canvas
+
+## What Claude Canvas Does
+
+- TUI toolkit for Claude Code - spawns interactive terminal interfaces
+- Use cases: emails, calendars, flight bookings, rich displays
+- Currently uses tmux for pane splitting
+- TypeScript + Bun stack
+- Installs as Claude Code plugin (`/plugin install canvas@claude-canvas`)
+- Proof-of-concept, currently unsupported by author
+
+## Goals
+
+1. **Investigate** - Understand the architecture and how panes are spawned
+2. **Ghostty support** - Replace/extend tmux dependency with Ghostty panes/tabs
+3. **Contribution path** - Either:
+   - Fork and maintain Atlas-specific version
+   - Create PR upstream to add Ghostty as terminal backend option
+4. **Utilities** - Identify additional utilities we could build on this foundation
+
+## Why Ghostty Instead of tmux
+
+- Native terminal experience (no tmux session management overhead)
+- Better integration with macOS
+- Ghostty's pane/tab API if available
+- Cleaner user experience for those not using tmux
+
+## Open Questions
+
+- Does Ghostty have a programmatic API for pane/tab control?
+- What's the abstraction layer in claude-canvas for tmux? (easy to swap?)
+- Is the project actively maintained? Worth PRing or forking?
+- What utilities would we build on top of this?
+- How does this interact with Atlas's current terminal workflow?
+
+## Related Ideas
+
+- [[atlas-as-claude-code-plugin]] - Both involve Claude Code plugin ecosystem

--- a/.claude/backlog/observability-dashboard-overhaul.md
+++ b/.claude/backlog/observability-dashboard-overhaul.md
@@ -1,0 +1,49 @@
+# Observability Dashboard Overhaul
+
+**Category:** observability
+**Captured:** 2026-01-17
+
+## Description
+
+Transform the current Vue-based observability dashboard into a standalone, LLM-agnostic application. Goals:
+
+1. **Framework migration** - Move from Vue to React/Next.js or Astro
+2. **UX improvements** - Tooltips, explanations, better data visualization
+3. **Accessibility** - Welcoming for first-time users AND seasoned practitioners
+4. **Standalone product** - Eventually break off from Atlas as its own tool
+5. **LLM-agnostic** - Support any AI coding agent, not just Claude Code
+
+## Target Platforms
+
+- Claude Code (current)
+- OpenAI Codex (any model)
+- Factory AI (droids)
+- Manus AI
+- DeepSeek
+- Ollama (local models)
+
+## Technical Requirements
+
+- TypeScript (strict)
+- Linting + formatting on every file edit (automated)
+- Consistent coding standards enforced
+- Use Atlas UI skill for design work
+- Architectural decision needed: Next.js vs pure React vs Astro
+
+## Origin
+
+Current observability dashboard works but is tightly coupled to Atlas and Claude Code. The data it surfaces is valuable for anyone doing agentic coding, regardless of their tool choice. Making it universal increases its utility and potential user base.
+
+## Open Questions
+
+- What's the right framework? (Next.js for SSR/routing, Astro for static, pure React for simplicity)
+- What data format would be universal across different AI agents?
+- How do different agents expose their telemetry/logs?
+- What metrics matter most to newcomers vs power users?
+- Should it be a desktop app (Electron/Tauri) or web-only?
+- What's the MVP feature set for standalone release?
+
+## Related Ideas
+
+- [[atlas-as-claude-code-plugin]] - Both aim for modularity and reduced lock-in
+- [[ui-skills-integration]] - Use for frontend development standards

--- a/.claude/backlog/research-evaluation-rigor.md
+++ b/.claude/backlog/research-evaluation-rigor.md
@@ -1,0 +1,63 @@
+# Research & Evaluation Rigor
+
+**Category:** skills / agents
+**Captured:** 2026-01-17
+
+## Description
+
+Improve Atlas's research agents and evaluation workflows to eliminate assumptions and increase transparency. When given vague directives like "evaluate this codebase," Atlas should prompt for clarity rather than making assumptions that lead to mistakes.
+
+## Current Problem
+
+- Vague requests lead to blind evaluation with unstated assumptions
+- No documentation of why certain paths were skipped
+- Decision criteria not captured or explained
+- User doesn't know what Atlas assumed vs. what was explicit
+- Mistakes happen when assumptions don't match user intent
+
+## Desired Behavior
+
+### 1. Clarification Before Action
+When given evaluation/research tasks, prompt for:
+- What specifically should be evaluated? (architecture, code quality, security, performance, etc.)
+- What's the success criteria?
+- What scope? (entire repo, specific directories, specific concerns)
+- What's the output format needed?
+
+### 2. Assumption Transparency
+- Document every assumption made
+- Flag when something is being skipped and why
+- Distinguish between "evaluated and found fine" vs "not evaluated"
+
+### 3. Decision Audit Trail
+- Capture criteria used for each decision
+- Explain reasoning, not just conclusions
+- Reference specific evidence (file:line, documentation, etc.)
+
+### 4. Skip Documentation
+When skipping something, document:
+- What was skipped
+- Why it was skipped (out of scope, not relevant, blocked, etc.)
+- Whether it should be revisited
+
+## Implementation Areas
+
+- Explore agent (Task tool with subagent_type=Explore)
+- Research workflows in Algorithm skill
+- Any evaluation-focused skills or commands
+- Agent prompts and system instructions
+
+## Origin
+
+Pattern of evaluations that miss important context because Atlas assumed scope or criteria instead of asking. Leads to rework and missed insights.
+
+## Open Questions
+
+- How to balance thoroughness with not over-prompting the user?
+- Should there be "quick eval" vs "thorough eval" modes?
+- How to persist evaluation context across sessions?
+- Should evaluation reports have a standard format?
+
+## Related Ideas
+
+- (none yet)

--- a/.claude/backlog/ui-skills-integration.md
+++ b/.claude/backlog/ui-skills-integration.md
@@ -1,0 +1,59 @@
+# UI Skills Integration
+
+**Category:** skills
+**Captured:** 2026-01-17
+
+## Description
+
+Integrate the ui-skills.com constraint system as an Atlas skill for frontend development. This provides opinionated standards for building interfaces with AI agents.
+
+**Source:** https://www.ui-skills.com/llms.txt
+
+## What UI Skills Provides
+
+1. **Stack requirements** - Tailwind CSS, motion/react for animations, cn utility for class composition
+2. **Component standards** - Accessible primitives (Base UI, React Aria, Radix), no mixing systems
+3. **Interaction patterns** - AlertDialog for destructive actions, errors adjacent to triggers
+4. **Animation rules** - Compositor properties only, 200ms max duration, respect motion preferences
+5. **Typography & layout** - Text balancing, fixed z-index scales, performance-aware
+6. **Design principles** - No gradients/glow as primary affordances, clear empty states
+
+## Usage Pattern
+
+- `/ui-skills` - Apply constraints broadly to current work
+- `/ui-skills <file>` - Review specific file for violations with explanations and fixes
+
+## Origin
+
+Needed for observability dashboard overhaul and any future frontend work. Want consistent, high-quality UI generation from AI.
+
+## Sub-items
+
+### Evaluate Additional Frontend Skills
+
+Research other frontend-focused skills/prompts in the ecosystem. Determine:
+- Are they complementary (install as separate skills)?
+- Are they overlapping (combine into unified UI skill)?
+- What's missing from ui-skills.com that others provide?
+
+**Sources to evaluate:**
+- [ui-skills.com](https://www.ui-skills.com/llms.txt) - Constraint-based rules (Tailwind, animations, accessibility)
+- [AI-Unleashed/frontend-design-shadcn](https://github.com/AI-Unleashed/Claude-Skills/blob/main/frontend-design-shadcn/SKILL.md) - Design philosophy + shadcn/ui scaffolding
+- [Anthropic/frontend-design](https://github.com/anthropics/claude-code/blob/main/plugins/frontend-design/skills/frontend-design/SKILL.md) - Official Claude Code plugin, design-first approach
+
+**Initial assessment:**
+- ui-skills.com = technical constraints (the "how")
+- frontend-design skills = creative philosophy (the "what")
+- These could be complementary: constraints + philosophy in one unified skill
+
+## Open Questions
+
+- Install as-is or adapt to Atlas skill format?
+- Does it conflict with any existing Atlas conventions?
+- Should it integrate with the Art skill for visual content?
+- How to handle projects that don't use Tailwind?
+- What other frontend skill sources exist in the Claude/AI ecosystem?
+
+## Related Ideas
+
+- [[observability-dashboard-overhaul]] - Primary use case for this skill

--- a/.claude/commands/local/sync-pai.md
+++ b/.claude/commands/local/sync-pai.md
@@ -1,0 +1,119 @@
+---
+description: "Sync PAI repository to Atlas"
+argument-hint: "[check|sync|diff]"
+---
+
+# Sync PAI to Atlas
+
+Synchronize Personal AI Infrastructure (PAI) releases into Atlas.
+
+## Source Repository
+- **Path:** `~/Developer/AI/PAI`
+- **Branch:** Always use `main` (latest)
+- **GitHub:** https://github.com/danielmiessler/Personal_AI_Infrastructure
+
+## Arguments
+$ARGUMENTS
+
+## Workflow
+
+### Step 1: Fetch Latest PAI
+```bash
+cd ~/Developer/AI/PAI && git fetch origin main && git checkout main && git pull
+```
+
+### Step 2: Check PAI Version
+```bash
+cd ~/Developer/AI/PAI && git log --oneline -5 && git describe --tags --always
+```
+
+### Step 3: Compare Packs
+
+For each PAI Pack, compare against Atlas:
+
+| PAI Pack | Atlas Location | Check |
+|----------|----------------|-------|
+| `pai-algorithm-skill/src/skills/THEALGORITHM/` | `~/.claude/skills/Algorithm/` | Tools, Phases, Reference, Data |
+| `pai-browser-skill/` | `~/.claude/skills/Browser/` | index.ts, Tools/ |
+| `pai-core-install/src/skills/CORE/` | `~/.claude/skills/CORE/` | USER/, SYSTEM/ (NOT SKILL.md) |
+| `pai-agents-skill/src/skills/Agents/` | `~/.claude/skills/Agents/` | Tools/, Data/, Workflows/ |
+| `pai-art-skill/src/skills/Art/` | `~/.claude/skills/Art/` | SKILL.md, Data/ |
+| `pai-prompting-skill/src/skills/Prompting/` | `~/.claude/skills/Prompting/` | Standards.md, Templates/ |
+| `pai-hook-system/src/hooks/` | `~/.claude/hooks/` | Core hooks only |
+| `pai-voice-system/src/voice/` | `~/.claude/voice/` | server.ts |
+
+### Step 4: For Each Difference Found
+
+Ask:
+1. **What changed?** (diff or new file)
+2. **How does it benefit Atlas?** (new feature, bug fix, improvement)
+3. **Any conflicts with local customizations?**
+4. **Sync this? [Yes/No/Skip]**
+
+### Step 5: Preserve Local Customizations
+
+**NEVER overwrite these Atlas-only files:**
+- `~/.claude/skills/CORE/SKILL.md` - Ed/Atlas identity
+- `~/.claude/skills/CORE/rules/*` - Modular rules architecture
+- `~/.claude/hooks/sync-issues-*.ts` - GitHub sync
+- `~/.claude/hooks/lib/github-sync/` - GitHub library
+- `~/.claude/hooks/lib/timestamps.ts` - Timestamp utils
+- `~/.claude/lib/config-loader.ts` - YAML voice config
+- `~/.claude/settings.json` - Hook configuration
+
+### Step 6: Path Translation
+
+When copying files from PAI:
+- Replace `$PAI_DIR/skills/THEALGORITHM/` → `~/.claude/skills/Algorithm/`
+- Replace `$PAI_DIR/skills/` → `~/.claude/skills/`
+- Replace `$PAI_DIR/MEMORY/` → `~/.claude/MEMORY/`
+- Replace `$PAI_DIR/` → `~/.claude/`
+
+## Commands
+
+### check (default)
+Compare PAI main vs Atlas and list differences:
+```bash
+# For each pack, compare directory contents
+diff -rq ~/Developer/AI/PAI/Packs/pai-algorithm-skill/src/skills/THEALGORITHM/Tools/ ~/.claude/skills/Algorithm/Tools/
+```
+
+### diff
+Show detailed diffs for specific files:
+```bash
+diff ~/Developer/AI/PAI/Packs/pai-algorithm-skill/src/skills/THEALGORITHM/SKILL.md ~/.claude/skills/Algorithm/SKILL.md
+```
+
+### sync
+Interactive sync with prompts for each change.
+
+## Quick Reference Commands
+
+```bash
+# Check for new files in PAI Algorithm
+ls ~/Developer/AI/PAI/Packs/pai-algorithm-skill/src/skills/THEALGORITHM/Tools/
+ls ~/.claude/skills/Algorithm/Tools/
+
+# Compare specific file
+diff ~/Developer/AI/PAI/Packs/pai-browser-skill/Tools/Browse.ts ~/.claude/skills/Browser/Tools/Browse.ts
+
+# Check PAI release notes
+cd ~/Developer/AI/PAI && git log --oneline v2.1.0..main
+
+# Copy a file with path translation
+cp ~/Developer/AI/PAI/Packs/pai-algorithm-skill/src/skills/THEALGORITHM/NewFile.ts ~/.claude/skills/Algorithm/NewFile.ts
+```
+
+## Benefits Tracking
+
+When syncing, document what each change provides:
+
+| Feature | Benefit |
+|---------|---------|
+| CapabilityLoader | Load capabilities by effort level |
+| CapabilitySelector | Auto-select capabilities for ISC rows |
+| RalphLoopExecutor | Persistent iteration loops |
+| TraitModifiers | Map effort to AgentFactory traits |
+| PAISECURITYSYSTEM | Comprehensive security patterns |
+| Browse.ts v1.2.0 | Debug-first browser automation |
+| BrowserSession.ts | Persistent browser sessions |

--- a/.claude/docs/ATLAS-COMMANDS.md
+++ b/.claude/docs/ATLAS-COMMANDS.md
@@ -8,30 +8,30 @@
 
 ## System Overview
 
-**Atlas** is a Personal AI Infrastructure (PAI) built on Claude Code that provides:
+**Atlas** is a Personal AI Infrastructure built on Claude Code that provides:
 - Voice personality management
 - Skill-based delegation
 - Real-time observability
 - Pack-based modularity
 - Stack preference enforcement
 
-The command system exposes 16 slash commands under the `atlas:` namespace.
+The command system exposes 22 slash commands under the `atlas:` namespace.
 
 ## Architecture
 
 ```
-~/.dotfiles/ai/.claude/commands/atlas/    # Source (git-tracked)
+~/.dotfiles/atlas/.claude/commands/atlas/    # Source (git-tracked)
             ↓ (stow)
-~/.claude/commands/atlas/                 # Installed (symlinked)
+~/.claude/commands/atlas/                    # Installed (symlinked)
             ↓ (Claude Code)
-/atlas:<command>                          # Available slash commands
+/atlas:<command>                             # Available slash commands
 ```
 
 **Key Directories:**
 - `~/.claude/hooks/` - Hook scripts (TypeScript, executed by bun)
 - `~/.claude/skills/` - Skill definitions (Markdown)
 - `~/.claude/observability/` - Real-time dashboard server
-- `~/Developer/AI/PAI/` - PAI pack repository
+- `~/.claude/MEMORY/` - History capture and state tracking
 
 **Runtime:** bun (NOT npm/yarn/pnpm)
 **Language:** TypeScript preferred over Python
@@ -229,77 +229,27 @@ PreToolUse:
 
 ---
 
-### Pack Management
+### Bundle Management
 
-Packs are self-contained markdown files that add capabilities to Atlas.
+Bundles are portable configurations for exporting and importing Atlas setups.
 
-#### `/atlas:pack [action] [name]`
-**Purpose:** Unified pack management - list available/installed packs or install new ones
-**Allowed Tools:** Read, Write, Edit, Bash
-**Source:** `~/Developer/AI/PAI/Packs/`
+#### `/atlas:bundle [action] [args]`
+**Purpose:** Manage Atlas bundles for portable configurations
+**Allowed Tools:** Read, Write, Bash
 
 **Subcommands:**
 | Command | Action |
 |---------|--------|
-| `/atlas:pack` | List all packs with installation status |
-| `/atlas:pack list` | Same as above |
-| `/atlas:pack install <name>` | Install a specific pack |
+| `/atlas:bundle list` | List available bundles |
+| `/atlas:bundle export` | Export current configuration |
+| `/atlas:bundle info <name>` | Show bundle details |
 
-**Categories:**
-- Feature Packs: `kai-*-system.md` (architecture systems)
-- Skill Packs: `kai-*-skill.md` (action-oriented capabilities)
-- Core Packs: `kai-core-*.md` (foundational infrastructure)
-
-**Example Output:**
-```
-📦 Atlas Pack System
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Feature Packs:
-  ✅ kai-history-system
-  ✅ kai-hook-system
-     kai-observability-server
-  ✅ kai-voice-system
-
-Skill Packs:
-  ✅ kai-agents-skill
-  ✅ kai-art-skill
-     kai-browser-skill
-  ✅ kai-prompting-skill
-
-Core Packs:
-  ✅ kai-core-install
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ = Installed
-
-Use: /atlas:pack install <pack-name>
-```
-
-**Installation Process:**
-1. Read pack file from `~/Developer/AI/PAI/Packs/<pack-name>.md`
-2. Parse contents (code files, settings, dependencies)
-3. Create required directories
-4. Write all code files
-5. Merge settings.json configuration (don't overwrite existing)
-6. Verify installation
-7. Report status
-
-**Example:**
-```
-/atlas:pack install kai-browser-skill
-```
+**Bundle Location:** `~/.claude/Bundles/`
 
 #### `/atlas:docs [doc]`
-**Purpose:** Access PAI documentation
+**Purpose:** Quick access to Atlas documentation
 **Parameters:**
 - `[doc]` - Optional. One of: readme, packs, platform, security
-
-**Available Docs:**
-- `readme` - PAI project overview
-- `packs` - Pack system documentation
-- `platform` - Platform architecture
-- `security` - Security protocols
 
 **Behavior:**
 - Without parameter: Lists available docs
@@ -311,7 +261,7 @@ Use: /atlas:pack install <pack-name>
 
 #### `/atlas:help`
 **Purpose:** Show complete command reference
-**Output:** Categorized list of all 17 commands with descriptions
+**Output:** Categorized list of all 22 commands with descriptions
 
 #### `/atlas:create-skill <name>`
 **Purpose:** Scaffold a new Atlas skill
@@ -420,11 +370,11 @@ Commands can start/stop the WebSocket server:
 **Required:**
 - `PAI_DIR` - Atlas installation directory (usually `~/.claude`)
 - `DA` - Digital Assistant name (Atlas)
-- `PAI_SOURCE_APP` - Source application (Atlas)
-- `TIME_ZONE` - User timezone (e.g., America/New_York)
+- `TIME_ZONE` - User timezone (e.g., America/Los_Angeles)
 
 **Optional:**
 - `ELEVENLABS_VOICE_*` - Voice IDs for TTS personalities
+- `ELEVENLABS_API_KEY` - API key for voice server
 
 ---
 
@@ -442,7 +392,7 @@ bash: /atlas:foo: No such file or directory
 ```
 ❌ Observability server not installed
 ```
-→ Install required pack: `/atlas:install kai-observability-server`
+→ Check installation: `/atlas:check`
 
 **Runtime Error:**
 ```
@@ -480,7 +430,7 @@ Commands use:
 ### File System Access
 Commands only access:
 - `~/.claude/` - Atlas installation directory
-- `~/Developer/AI/PAI/` - PAI pack repository
+- `~/.dotfiles/atlas/` - Source repository (git-tracked)
 - Current working directory (read-only)
 
 ---
@@ -518,12 +468,11 @@ tail ~/.claude/observability/apps/server/logs/*.log
 
 ## Version Information
 
-- **Command System Version:** 1.0.2
-- **Total Commands:** 18
+- **Command System Version:** 1.1.0
+- **Total Commands:** 22
 - **Namespace:** `atlas:`
 - **Runtime:** bun
 - **Platform:** Claude Code
-- **Compatible With:** PAI Pack System v1.0+
 
 ---
 
@@ -531,7 +480,7 @@ tail ~/.claude/observability/apps/server/logs/*.log
 
 ### Adding New Commands
 
-1. Create `.md` file: `ai/.claude/commands/atlas:<name>.md`
+1. Create `.md` file: `.claude/commands/atlas/<name>.md`
 2. Add frontmatter:
    ```yaml
    ---
@@ -542,23 +491,22 @@ tail ~/.claude/observability/apps/server/logs/*.log
 3. Document usage with `$ARGUMENTS`, `$1`, `$2`
 4. Prefix shell commands with `!`
 5. Update `/atlas:help` command
-6. Update `README.md`
-7. Update this file (ATLAS_COMMANDS.md)
+6. Update this file (ATLAS-COMMANDS.md)
 
 ### Testing Commands
 
 ```bash
 # Test locally (before stowing)
-cat ai/.claude/commands/atlas:test.md
+cat ~/.dotfiles/atlas/.claude/commands/atlas/<name>.md
 
 # Install via stow
-cd ~/.dotfiles && make update
+cd ~/.dotfiles && stow atlas
 
 # Verify installation
-ls ~/.claude/commands/atlas:test.md
+ls ~/.claude/commands/atlas/<name>.md
 
 # Test in Claude Code
-/atlas:test
+/atlas:<name>
 ```
 
 ### Debugging Commands
@@ -578,14 +526,14 @@ bash -x <(sed -n '/^!/p' ~/.claude/commands/atlas:<name>.md | sed 's/^!//')
 
 ## Related Documentation
 
-- **User README:** `ai/.claude/commands/README.md`
-- **PAI Documentation:** `~/Developer/AI/PAI/README.md`
-- **Pack System:** `~/Developer/AI/PAI/PACKS.md`
+- **User README:** `~/.dotfiles/atlas/README.md`
 - **Skills Index:** `~/.claude/skills/skill-index.json`
 - **Hook System:** `~/.claude/settings.json`
+- **Hooks Documentation:** `~/.claude/docs/HOOKS-SYSTEM.md`
+- **Voice System:** `~/.claude/docs/VOICE-SYSTEM.md`
 
 ---
 
-**Last Updated:** 2026-01-07
-**Maintained By:** Ed (Atlas user)
+**Last Updated:** 2026-01-19
+**Maintained By:** Ed
 **For AI Agents:** This document is authoritative for Atlas command system integration

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Atlas
 
-**Personal AI Infrastructure for Claude Code**
+**Personal AI Agent for Claude Code**
 
 [![Built with Claude](https://img.shields.io/badge/Built_with-Claude-D4A574?style=flat&logo=anthropic&logoColor=white)](https://claude.ai)
 [![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## What is Atlas?
 
-Atlas extends [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with modular capabilities that make your AI assistant *yours* - persistent memory, life goals context, voice feedback, and more.
+Atlas extends [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with modular capabilities that make your AI agent *yours* - persistent memory, context for life goals, voice feedback, and more.
 
 ```mermaid
 flowchart TB
@@ -80,7 +80,7 @@ cd atlas
 
 The wizard will:
 1. Let you select which modules to install
-2. Ask for your AI's name (default: Atlas)
+2. Ask for your Agent's name (default: Atlas)
 3. Ask for your name (for personalized greetings)
 
 ### Option 2: Install Specific Modules
@@ -250,7 +250,7 @@ Find voice IDs at [ElevenLabs Voice Library](https://elevenlabs.io/voice-library
 
 ### Identity
 
-Your AI assistant has a configurable identity that personalizes every interaction.
+Your AI agent has a configurable identity that personalizes every interaction.
 
 ```mermaid
 flowchart LR
@@ -278,7 +278,7 @@ The wizard prompts for identity configuration:
 ```
 ━━━ Identity Configuration ━━━
 
-AI Assistant name [Atlas]: Jarvis
+AI Agent name [Atlas]: Jarvis
 Your name: Tony
 
 Identity configured:
@@ -312,7 +312,7 @@ Edit the Identity section:
 - Name: Tony
 ```
 
-### TELOS (Life Goals)
+### DELTA (Progress & Growth in Life)
 
 ```bash
 code ~/.claude/skills/CORE/USER/TELOS.md
@@ -349,7 +349,7 @@ Or from within Claude Code: `/atlas:modules`
 
 ---
 
-## Local Commands
+## Local Commands (More than projects needs)
 
 Create machine-specific commands that aren't tracked in git.
 
@@ -366,7 +366,7 @@ Commands become available as `/local:<name>`. For example, `sync-tools.md` becom
 **Use cases:**
 - Commands referencing local paths (`~/Developer/...`)
 - Sync scripts for local repositories
-- Machine-specific workflows
+- Machine-specific workflows (MacDaddy-M1Air, BigMac-MacStudioM1Ultra)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add feature backlog directory with 5 captured ideas for future development
- Add local commands directory for machine-specific commands
- Update ATLAS-COMMANDS.md to v1.1.0 reflecting 22 commands
- Remove PAI-specific references, update paths to current atlas structure

## Test plan
- [ ] Verify backlog files are accessible and properly formatted
- [ ] Confirm local commands directory structure
- [ ] Check ATLAS-COMMANDS.md reflects current command inventory

🤖 Generated with [Claude Code](https://claude.com/claude-code)